### PR TITLE
Fix MapGenStructure saving data globally rather than per world, causi…

### DIFF
--- a/patches/net/minecraft/world/gen/structure/MapGenStructure.java.patch
+++ b/patches/net/minecraft/world/gen/structure/MapGenStructure.java.patch
@@ -8,7 +8,7 @@
 +            // Spigot Start
 +            if (p_143027_1_.getSpigotConfig().saveStructureInfo && !this.func_143025_a().equals("Mineshaft")) // Cauldron
 +            {
-+                this.field_143029_e = (MapGenStructureData) p_143027_1_.loadItemData(MapGenStructureData.class, this.func_143025_a());
++                this.field_143029_e = (MapGenStructureData) p_143027_1_.perWorldStorage.loadData(MapGenStructureData.class, this.func_143025_a());
 +            }
 +            else
 +            {


### PR DESCRIPTION
…ng structures from certain mods to spawn in the wrong dimensions